### PR TITLE
Allow bytestring 0.11

### DIFF
--- a/HsYAML-aeson.cabal
+++ b/HsYAML-aeson.cabal
@@ -38,7 +38,7 @@ library
     , HsYAML      ^>= 0.2.0
     , aeson        >= 1.4.0.0 && < 1.6
     , base         >= 4.5 && < 4.15
-    , bytestring  ^>= 0.9.2.1 || ^>= 0.10.0.2
+    , bytestring  ^>= 0.9.2.1 || ^>= 0.10.0.2 || ^>= 0.11.0.0
     , containers   >=0.4.2 && <0.7
     , mtl         ^>= 2.2.1
     , scientific  ^>= 0.3.6.2


### PR DESCRIPTION
Tested locally with

```
$ cabal build -O0 --constraint 'bytestring>=0.11' all --allow-newer='attoparsec:bytestring,uuid-types:bytestring,HsYAML:bytestring'
```