### PR TITLE
Allow base-4.16 for GHC 9.0

### DIFF
--- a/HsYAML-aeson.cabal
+++ b/HsYAML-aeson.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
     , HsYAML      ^>= 0.2.0
     , aeson        >= 1.4.0.0 && < 1.6
-    , base         >= 4.5 && < 4.15
+    , base         >= 4.5 && < 4.16
     , bytestring  ^>= 0.9.2.1 || ^>= 0.10.0.2
     , containers   >=0.4.2 && <0.7
     , mtl         ^>= 2.2.1


### PR DESCRIPTION
Closes #9.